### PR TITLE
Lock down versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "coveralls": "npm run report && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
   },
   "dependencies": {
-    "bellajs": "latest",
-    "bluebird": "latest",
-    "request": "latest"
+    "bellajs": "5.1.3",
+    "bluebird": "3.4.0",
+    "request": "2.72.0"
   },
   "devDependencies": {
     "chai": "latest",


### PR DESCRIPTION
So, we were bitten by a problem where the bellajs module was updated and broke our application. It's a best practice, I think, to lock dependencies for a module to specific versions and not use `latest`. These versions in this PR work for us, but not sure if you want to lock this as the node 4 version and then publish a node 6 version, but, regardless, you may want to consider using specific versions.

I hope this makes sense. Thanks for writing these modules, btw. They're great and very useful for us.